### PR TITLE
pager: expose QueryPager::next() under flag

### DIFF
--- a/scylla/Cargo.toml
+++ b/scylla/Cargo.toml
@@ -146,4 +146,5 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(cassandra_tests)',
     'cfg(cpp_rust_unstable)',
     'cfg(ccm_tests)',
+    'cfg(csharp_rs_unstable)',
 ] }

--- a/scylla/src/client/pager.rs
+++ b/scylla/src/client/pager.rs
@@ -638,6 +638,18 @@ impl QueryPager {
         )
     }
 
+    /// This is essentially the same as `next()`, but it is *public* and only available
+    /// when the `csharp-rs-unstable` feature is enabled.
+    /// Rationale: I don't know a way to make a function conditionally public,
+    /// based on a compile-time flag, so I added an new wrapper function
+    /// that is conditionally compiled and is public.
+    #[cfg(csharp_rs_unstable)]
+    pub async fn next_column_iterator(
+        &mut self,
+    ) -> Option<Result<ColumnIterator<'_, '_>, NextRowError>> {
+        self.next().await
+    }
+
     /// Tries to acquire a non-empty page, if current page is exhausted.
     fn poll_fill_page(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
If `csharp-rs-unstable` flag is enabled, then `QueryPager::next_column_iterator()` is available and public, and is essentially a wrapper around `QueryPager::next()`.

Rationale: `QueryPager::next()` is the only way to achieve borrowed deserialization using `QueryPager`, but it is private. C# wrapper will benefit from having access to it, so I made it available under a dedicated flag, similarly to how `cpp-rust-unstable` flag works.